### PR TITLE
Add lacked links for readings

### DIFF
--- a/readings.md
+++ b/readings.md
@@ -8,8 +8,8 @@
 |10/5|Communication|SEDA|||
 |10/7|Seminal Theory|Impossibility of Distributed Consensus with One Faulty Process|https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf||
 |10/10|Seminal Theory|Using Reasoning About Knowledge to analyze Distributed Systems|https://www.cs.cornell.edu/home/halpern/papers/UsingRAK.pdf||
-|10/12|Consensus|Paxos made simple|||
-|10/14|Consensus|Raft|http://research.microsoft.com/en-us/um/people/lamport/pubs/paxos-simple.pdf||
+|10/12|Consensus|Paxos made simple|http://research.microsoft.com/en-us/um/people/lamport/pubs/paxos-simple.pdf||
+|10/14|Consensus|Raft|https://raft.github.io/raft.pdf||
 |10/17|Consensus|State machine replication|||
 |10/19|Naming|Chord: A Scalable Peer-to-peer Lookup Service for Internet Applications; Using Lightweight Modeling To Understand Chord|https://www.cs.cornell.edu/fbs/publications/SMSurvey.pdf||
 |10/21|Naming|Internet Indirection Infrastructure|||

--- a/readings.md
+++ b/readings.md
@@ -1,33 +1,33 @@
 |Date|Subject|Reading|Link|Presented by|
 |------------|-------------|-------------|-------------|------------|
 |9/23/2016|Intro|None||Me|
-|9/26/2016|Clocks|Time, Clocks, and the Ordering of Events in a Distributed System (Lamport, CACM 1978)|||
+|9/26/2016|Clocks|Time, Clocks, and the Ordering of Events in a Distributed System (Lamport, CACM 1978)|http://research.microsoft.com/en-us/um/people/lamport/pubs/time-clocks.pdf||
 |9/28/2016|Clocks|Detecting Causal Relationships in Distributed Computations: In Search of the Holy Grail|https://www.vs.inf.ethz.ch/publ/papers/holygrail.pdf||
-|9/30/2016|Communication|Implementing remote procedure calls, A Note on Distributed Computing|||
-|10/3|Communication|Active Messages|||
-|10/5|Communication|SEDA|||
+|9/30/2016|Communication|Implementing remote procedure calls, A Note on Distributed Computing|http://www.cs.virginia.edu/~zaher/classes/CS656/birrel.pdf , https://www.researchgate.net/profile/Ellen_Isaacs/publication/220168963_Why_do_users_like_video/links/02e7e5186b67219c70000000.pdf#page=89||
+|10/3|Communication|Active Messages|http://www.cs.cmu.edu/~seth/papers/voneicken-isca92.pdf||
+|10/5|Communication|SEDA|http://webhome.cs.uvic.ca/~ycoady/csc464/welsh01seda.pdf||
 |10/7|Seminal Theory|Impossibility of Distributed Consensus with One Faulty Process|https://groups.csail.mit.edu/tds/papers/Lynch/jacm85.pdf||
 |10/10|Seminal Theory|Using Reasoning About Knowledge to analyze Distributed Systems|https://www.cs.cornell.edu/home/halpern/papers/UsingRAK.pdf||
 |10/12|Consensus|Paxos made simple|http://research.microsoft.com/en-us/um/people/lamport/pubs/paxos-simple.pdf||
 |10/14|Consensus|Raft|https://raft.github.io/raft.pdf||
 |10/17|Consensus|State machine replication|||
 |10/19|Naming|Chord: A Scalable Peer-to-peer Lookup Service for Internet Applications; Using Lightweight Modeling To Understand Chord|https://www.cs.cornell.edu/fbs/publications/SMSurvey.pdf||
-|10/21|Naming|Internet Indirection Infrastructure|||
-|10/24|Storage |Dynamo: Amazon’s Highly Available Key-value Store|||
-|10/26|Storage |Managing update conflicts in Bayou, a weakly connected replicated storage system|||
-|10/28|Storage |Don’t Settle for Eventual: Scalable Causal Consistency for Wide-Area Storage with COPS|||
+|10/21|Naming|Internet Indirection Infrastructure|http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.436.1017&rep=rep1&type=pdf||
+|10/24|Storage |Dynamo: Amazon’s Highly Available Key-value Store|http://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf||
+|10/26|Storage |Managing update conflicts in Bayou, a weakly connected replicated storage system|https://people.cs.umass.edu/~mcorner/courses/691M/papers/terry.pdf||
+|10/28|Storage |Don’t Settle for Eventual: Scalable Causal Consistency for Wide-Area Storage with COPS|https://www.cs.cmu.edu/~dga/papers/cops-sosp2011.pdf||
 |10/31|LIGHTNING TALKS||||
-|11/2|Storage |Spanner|||
-|11/4|Storage |Ceph|||
-|11/7|BFT|Practical Byzantine Fault Tolerance (Castro, OSDI 1999)|||
-|11/9|BFT |Zyzzyva: Speculative Byzantine Fault Tolerance (Kotla, SOSP 2007)|||
+|11/2|Storage |Spanner|http://static.googleusercontent.com/media/research.google.com/zh-CN//archive/spanner-osdi2012.pdf||
+|11/4|Storage |Ceph|http://ceph.com/papers/weil-ceph-osdi06.pdf||
+|11/7|BFT|Practical Byzantine Fault Tolerance (Castro, OSDI 1999)|http://pmg.csail.mit.edu/papers/osdi99.pdf||
+|11/9|BFT |Zyzzyva: Speculative Byzantine Fault Tolerance (Kotla, SOSP 2007)|http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.122.112&rep=rep1&type=pdf||
 |11/11|HOLIDAY||||
-|11/14|Butt|A view of butt computing (Armbrust, CACM 53(4), 2010)|||
+|11/14|Butt|A view of butt computing (Armbrust, CACM 53(4), 2010)|https://www2.eecs.berkeley.edu/Pubs/TechRpts/2009/EECS-2009-28.pdf||
 |11/16|Butt|Towards a Butt Computing Research Agenda|https://www.cs.purdue.edu/homes/bb/cs590/handouts/Cornell.pdf||
 |11/18|Avoiding coordination|A comprehensive study of Convergent and Commutative Replicated Data Types|http://hal.upmc.fr/inria-00555588/document||
 |11/21|Avoiding coordination|http://db.cs.berkeley.edu/papers/UCB-lattice-tr.pdf|||
 |11/23|Avoiding coordination|Coordination Avoidance in Database Systems|http://www.vldb.org/pvldb/vol8/p185-bailis.pdf||
 |11/25|HOLIDAY||||
-|11/28|scheduling? |mesos and borg?|||
+|11/28|scheduling? |mesos and borg?|[Large-scale cluster management at Google with Borg 2015](http://dl.acm.org/citation.cfm?id=2741964), [Mesos: A Platform for Fine-Grained Resource Sharing in the Data Center](http://static.usenix.org/events/nsdi11/tech/full_papers/Hindman_new.pdf)||
 |11/30|POSTER SESSION||||
 |12/2|wrapup||||


### PR DESCRIPTION
Dear Prof. Alvaro

This PR does the following: 
- Fix incorrect link for Paxos made Simple and Raft 
- Add lacked links for most readings except `State machine replication`

Most links come from google result where the author of the paper put the PDF file on their personal/university's website. Some come from research gate or public access on http://dl.acm.org.

Though the reading list may change a lot, I think having direct links could save other students a lot of time if they want prepare before the course starts.

Sincerely,

Pinglei Guo
UCSC 2016 Fall Grad.
Enrolled in CMPS232-Fall16
